### PR TITLE
Add setting to disable craftitems

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -68,6 +68,7 @@ ju52.textures = {
     --"ju52_white.png", --asas
 }
 
+
 dofile(minetest.get_modpath("ju52") .. DIR_DELIM .. "ju52_global_definitions.lua")
 dofile(minetest.get_modpath("ju52") .. DIR_DELIM .. "ju52_crafts.lua")
 dofile(minetest.get_modpath("ju52") .. DIR_DELIM .. "ju52_control.lua")

--- a/ju52_crafts.lua
+++ b/ju52_crafts.lua
@@ -1,15 +1,16 @@
 -- wing
-minetest.register_craftitem("ju52:wings",{
-	description = "Ju52 wings",
-	inventory_image = "ju52_wings.png",
-})
+if not minetest.settings:get_bool('ju52.disable_craftitems') then
+    minetest.register_craftitem("ju52:wings",{
+	    description = "Ju52 wings",
+	    inventory_image = "ju52_wings.png",
+    })
 -- fuselage
-minetest.register_craftitem("ju52:body",{
-	description = "Ju52 body",
-	inventory_image = "ju52_body.png",
-})
-
--- trike
+    minetest.register_craftitem("ju52:body",{
+	    description = "Ju52 body",
+	    inventory_image = "ju52_body.png",
+    })
+end
+-- ju52
 minetest.register_craftitem("ju52:ju52", {
 	description = "Ju 52",
 	inventory_image = "ju52.png",
@@ -43,8 +44,7 @@ minetest.register_craftitem("ju52:ju52", {
 --
 -- crafting
 --
-
-if minetest.get_modpath("default") then
+if not minetest.settings:get_bool('ju52.disable_craftitems') and minetest.get_modpath("default") then
 	--[[minetest.register_craft({
 		output = "ju52:wings",
 		recipe = {
@@ -69,3 +69,4 @@ if minetest.get_modpath("default") then
 		}
 	})]]--
 end
+

--- a/ju52_utilities.lua
+++ b/ju52_utilities.lua
@@ -289,23 +289,24 @@ function ju52.destroy(self)
 
     airutils.destroy_inventory(self)
     self.object:remove()
+    if not minetest.settings:get_bool('ju52.disable_craftitems') then
+        pos.y=pos.y+2
+        minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'ju52:wings')
 
-    pos.y=pos.y+2
-    minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'ju52:wings')
+        for i=1,6 do
+	        minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:steel_ingot')
+        end
 
-    for i=1,6 do
-	    minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:steel_ingot')
+        for i=1,4 do
+	        minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:wood')
+        end
+
+        for i=1,6 do
+	        minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:mese_crystal')
+        end
+    else
+        minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'ju52:ju52')
     end
-
-    for i=1,4 do
-	    minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:wood')
-    end
-
-    for i=1,6 do
-	    minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:mese_crystal')
-    end
-
-    --minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'ju52:ju52')
 end
 
 function ju52.testDamage(self, velocity, position)


### PR DESCRIPTION
Adds a setting called "ju52.disable_craftitems" that will disable ju52 craftitems and drop a ju52 when broken instead of materials. Good option for creative or economy servers.